### PR TITLE
Fix canMakePayments()

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -479,7 +479,7 @@ export default class PaymentRequest {
   // https://www.w3.org/TR/payment-request/#canmakepayment-method
   canMakePayments(): Promise<boolean> {
     return NativePayments.canMakePayments(
-      getPlatformMethodData(JSON.parse(this._serializedMethodData, Platform.OS))
+      getPlatformMethodData(JSON.parse(this._serializedMethodData), Platform.OS)
     );
   }
 }


### PR DESCRIPTION
Fails because the Platform.OS constant is not passed to the method.